### PR TITLE
Fix typos

### DIFF
--- a/auction/README.md
+++ b/auction/README.md
@@ -12,7 +12,7 @@ In this model, there are two parties: the auctioneer and the bidders.
 - **Bidder**: A participant in the auction.
 - **Auctioneer**: The party responsible for conducting the auction.
 
-We make following assumptions about the auction:
+We make the following assumptions about the auction:
 - The auctioneer is honest. That is, the auctioneer will resolve **all** bids in the order they are received. The auctioneer will not tamper with the bids.
 - There is no limit to the number of bids.
 - The auctioneer knows the identity of all bidders, but bidders do not necessarily know the identity of other bidders.

--- a/auction/src/main.leo
+++ b/auction/src/main.leo
@@ -49,7 +49,7 @@ program auction.aleo {
         }
     }
 
-    // Returns ownership of the bid to bidder.
+    // Returns ownership of the bid to the bidder.
     // - `bid` : The winning bid.
     // Requires that the function caller is the auction runner.
     // Assumes that the function is invoked only after all bids have been resolved.

--- a/basic_bank/src/main.leo
+++ b/basic_bank/src/main.leo
@@ -8,7 +8,7 @@ program basic_bank.aleo {
     }
 
     // An on-chain mapping, storing the amount of tokens owned by each account
-    // The account is stored as a to preserve user privacy.
+    // The account is stored as to preserve user privacy.
     mapping balances: field => u64;
 
     // Returns a new Token.

--- a/battleship/README.md
+++ b/battleship/README.md
@@ -296,7 +296,7 @@ leo run play "{
 ✅ Executed 'battleship.aleo/play'
 ```
 
-Player 1 has an updated `board_state.record` - they have a new `played_tiles` bitstring, which corresponds to the fire coordinate they just sent to Player 2. You can see that the `incoming_fire_coordinate` in the `move.record` owned by Player 2 matches exactly the input given by Player 1. Player 2 can now play this move tile and respond with a fire coordinate of their own, and they will also let Player 1 know whether their fire coordinate hit or miss Player 2's ships.
+Player 1 has an updated `board_state.record` - they have a new `played_tiles` bitstring, which corresponds to the fire coordinate they just sent to Player 2. You can see that the `incoming_fire_coordinate` in the `move.record` owned by Player 2 matches exactly the input given by Player 1. Player 2 can now play this move tile and respond with a fire coordinate of their own, and they will also let Player 1 know whether their fire coordinate hit or misses Player 2's ships.
 
 ## 7: Player 2 Takes The 2nd Turn
 

--- a/battleship/imports/board.leo
+++ b/battleship/imports/board.leo
@@ -13,7 +13,7 @@ program board.aleo {
         hits_and_misses: u64,
         // The squares that have been played on the opponent's board.
         played_tiles: u64,
-        // The ship bitstring representing all ship positions on your own board
+        // The ship bitstring represents all ship positions on your own board
         ships: u64,
         player_1: address,
         player_2: address,

--- a/battleship/imports/verify.leo
+++ b/battleship/imports/verify.leo
@@ -22,7 +22,7 @@ program verify.aleo {
         return r11;
     }
 
-    // Returns boolean of whether all the flipped bits in location are "adjacent". Horizontally, this means all flipped bits are
+    // Returns boolean of whether all the flipped bits in the location are "adjacent". Horizontally, this means all flipped bits are
     // directly next to each other (111). Vertically, this means all flipped bits are separated by 7 unflipped bits
     // (10000000100000001).
     function adjacency_check(

--- a/battleship/src/main.leo
+++ b/battleship/src/main.leo
@@ -71,7 +71,7 @@ program battleship.aleo {
     }
 
     // Returns updated board record.
-    // Returns new move record owned by opponent.
+    // Returns new move record owned by the opponent.
     transition play(
         // The board record to update.
         board: board.aleo/board_state.record,
@@ -91,7 +91,7 @@ program battleship.aleo {
         // Play coordinate on own board. Will fail if not a valid move.
         let hit_or_miss: board.aleo/board_state = board.aleo/update_played_tiles(board, shoot);
 
-        // Update own board with result of last shot.
+        // Update your own board with the result of last shot.
         let next_board: board.aleo/board_state = board.aleo/update_hits_and_misses(hit_or_miss, move_incoming.prev_hit_or_miss);
 
         // Assess whether incoming fire coordinate is a hit.

--- a/tictactoe/README.md
+++ b/tictactoe/README.md
@@ -49,7 +49,7 @@ We generate the board, and then the player take turns executing the transition f
 
 The inputs to the function are the player number, row position, column position, and the previous state of the board.
 
-The output provided is the new state of the board and an evaluation of who won the game. 0u8 as the evaluation output means a draw if the board is complete or that the game is not yet over.
+The output provided is the new state of the board and an evaluation of who won the game. 0u8 as the evaluation output means a draw if the board is complete or if the game is not yet over.
 
 ```bash
 leo run new


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

